### PR TITLE
PNDA-4431: Add basic console elements to represent Flink in PNDA

### DIFF
--- a/console-frontend/conf/dummy-metrics.json
+++ b/console-frontend/conf/dummy-metrics.json
@@ -12,6 +12,7 @@
     {"name": "hadoop.ZOOKEEPER.health", "hadoop_distro": "CDH,HDP"},
     {"name": "kafka.health", "hadoop_distro": "CDH,HDP"},
     {"name": "zookeeper.health", "hadoop_distro": "CDH,HDP"},
-    {"name": "opentsdb.health", "hadoop_distro": "CDH,HDP"}
+    {"name": "opentsdb.health", "hadoop_distro": "CDH,HDP"},
+    {"name": "flink.health", "hadoop_distro": "CDH,HDP"}
 ]
 }

--- a/console-frontend/help/topics.json
+++ b/console-frontend/help/topics.json
@@ -52,6 +52,11 @@
         "In PNDA, it allows for both batch mode and streaming computation."],
       "link": "http://spark.apache.org"
     },
+     "flink.health": {
+      "body": ["Apache Flink® is an open-source stream processing framework for distributed, high-performing, always-available, and accurate data streaming applications.",
+        "In PNDA, it allows for both batch mode and streaming computation."],
+      "link": "http://flink.apache.org/"
+    },
     "hadoop.OOZIE.health": {
       "body": ["Apache Oozie is a workflow scheduler system to manage Apache Hadoop jobs.",
         "In PNDA, batch mode Spark jobs are run on a regular schedule by Oozie."],

--- a/console-frontend/js/controllers/MetricsListCtrl.js
+++ b/console-frontend/js/controllers/MetricsListCtrl.js
@@ -306,6 +306,7 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
     function findResolutionUrlForSource(source, showDefault) {
       var resolutionUrl = "/";
       var opentsdbIndex = "OpenTSDB";
+      var flinkIndex = "Flink";
       if ($scope.dm_endpoints !== undefined) {
         if (source === "kafka") {
           resolutionUrl = $scope.dm_endpoints.kafka_manager;
@@ -332,7 +333,10 @@ angular.module('appControllers').controller('MetricListCtrl', ['$scope', 'Metric
         } else if (source === "OOZIE") {
           resolutionUrl = ConfigService.userInterfaceIndex["Hadoop Cluster Manager"] +
             '#/main/views/WORKFLOW_MANAGER/1.0.0/PNDA_WORKFLOW';
-        } else if (source === "AMBARI" || source === "CM") {
+        } else if (source === "flink") {
+            resolutionUrl = ConfigService.userInterfaceIndex[flinkIndex];
+        }
+		else if (source === "AMBARI" || source === "CM") {
           resolutionUrl = ConfigService.userInterfaceIndex["Hadoop Cluster Manager"];
         } else if ($scope.dm_endpoints.cm_status_links !== undefined) {
           resolutionUrl = $scope.dm_endpoints.cm_status_links[source];

--- a/console-frontend/js/filters.js
+++ b/console-frontend/js/filters.js
@@ -294,6 +294,9 @@ metricFilters.filter('metricNameForDisplay', function() {
       case "hadoop.SPARK_ON_YARN.health":
         display = "Spark";
         break;
+      case "flink.health":
+          display = "Flink";
+          break;
     }
     return display;
   };

--- a/console-frontend/partials/curated-view.html
+++ b/console-frontend/partials/curated-view.html
@@ -58,6 +58,9 @@
                             <div class="content">
                               <pnda-basic-component overwrite-display-name="Spark Streaming" force-wrap-display-name="true" on-get-metric-data="getMetricData('hadoop.SPARK_ON_YARN',cbFn,healthStatusCbFn)" show-overview="showModal(metricObj, metrics)" show-config="showConfigPage(metricObj)"></pnda-basic-component>
                             </div>
+                            <div class="content">
+                              <pnda-basic-component force-wrap-display-name="true" on-get-metric-data="getMetricData('flink',cbFn,healthStatusCbFn)" show-overview="showModal(metricObj, metrics)" show-config="showConfigPage(metricObj)"></pnda-basic-component>
+                            </div>
                           </div>
                         </div>
                         <div class="col-md-6">
@@ -66,6 +69,11 @@
                             <div class="content row">
                               <div class="col-md-12">
                                 <pnda-basic-component on-get-metric-data="getMetricData('hadoop.SPARK_ON_YARN',cbFn,healthStatusCbFn,true)" show-overview="showModal(metricObj, metrics)" show-config="showConfigPage(metricObj)"></pnda-basic-component>
+                              </div>
+                            </div>
+                            <div class="content row">
+                              <div class="col-md-12">
+                                <pnda-basic-component on-get-metric-data="getMetricData('flink',cbFn,healthStatusCbFn,true)" show-overview="showModal(metricObj, metrics)" show-config="showConfigPage(metricObj)"></pnda-basic-component>
                               </div>
                             </div>
                             <div class="content row">


### PR DESCRIPTION
# Problem Statement:
PNDA-4431: Add basic console elements to represent Flink in PNDA

# Analysis:
currently, Flink is not available to the PNDA console elements on dashboard. 

# Change:
Added the flink to the console elements.

# Test details:
Verified the fix for AWS:
UBUNTU - PICO -CDH & HDP
UBUNTU - STD -CDH & HDP
RHEL - PICO -CDH & HDP
RHEL - STD -CDH & HDP
Verification Done for openstack.
